### PR TITLE
修改 Cargo.toml 的写法，以根据平台自动切换后端

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,10 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = "0.4"
 
-[dependencies.cursive]
-version = "0.20"
-default-features = false
+[target.'cfg(not(windows))'.dependencies]
+cursive = { version = "0.20" }
 
-[features]
-default = ["ncurses-backend"]
-ncurses-backend = ["cursive/ncurses-backend"]
-crossterm-backend = ["cursive/crossterm-backend"]
+[target.'cfg(windows)'.dependencies]
+cursive = { version = "0.20", default-features = false, features = [
+  "crossterm-backend",
+] }

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -44,7 +44,7 @@ impl Server {
     }
 
     fn remove_member(&mut self, addr: &SocketAddr) -> bool {
-        self.members.remove(&addr)
+        self.members.remove(addr)
     }
 
     fn send_to_all(&mut self, msg: &Message) {

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -70,12 +70,12 @@ impl Server {
     fn parse_msg(&mut self, raw: &[u8], src: SocketAddr) {
         let utf8msg = match from_utf8(raw) {
             Ok(utf8msg) => utf8msg,
-            Err(_) => return
+            Err(_) => return,
         };
         println!("[{}]{}", src, utf8msg);
         let msg: Message = match serde_json::from_str(utf8msg) {
             Ok(msg) => msg,
-            Err(_) => return
+            Err(_) => return,
         };
         match msg.get_code() {
             ControlCode::Error => self.handle_msg_error(msg, src),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,7 @@ use std::net::SocketAddr;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone)]
-#[derive(Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq)]
 pub enum ControlCode {
     SendMessage,
     JoinGroup,
@@ -13,8 +12,7 @@ pub enum ControlCode {
     Error,
 }
 
-#[derive(Clone)]
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Member {
     nickname: String,
     address: SocketAddr,
@@ -42,8 +40,7 @@ impl Member {
     }
 }
 
-#[derive(Clone)]
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Group {
     name: String,
     id: u64,
@@ -71,8 +68,7 @@ impl Group {
     }
 }
 
-#[derive(Clone)]
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Message {
     code: ControlCode,
     timestamp: i64,
@@ -82,7 +78,13 @@ pub struct Message {
 }
 
 impl Message {
-    pub fn new(code: ControlCode, timestamp: i64, group: Group, sender: Member, msg: String) -> Message {
+    pub fn new(
+        code: ControlCode,
+        timestamp: i64,
+        group: Group,
+        sender: Member,
+        msg: String,
+    ) -> Message {
         Message {
             code,
             timestamp,


### PR DESCRIPTION
Cargo.toml 支持 `[target.'cfg(not(windows))'.dependencies]` 的方式添加特定于平台的依赖。

因此我们可以在 windows 上开启 `crossterm-backend` 而在其他平台仍使用 `ncurses-backend`。

这样的好处是会自动切换后端，不用额外加入 `--no-default-features --features xxx` 等参数。

经过测试，cursive 的 `pancurses-backend` 会额外打开一个窗口，而非在原来的终端上创建 TUI。因此还是选择在 windows 上使用 crossterm 作为后端。

此外，本 PR 还运行了 cargo fmt 进行格式化清理工作，以及 cargo clippy 进行 lint。